### PR TITLE
Fix TypeError on assign trackDay from schedule JSON

### DIFF
--- a/js/partials.js
+++ b/js/partials.js
@@ -36,7 +36,7 @@ fetch("data/schedule.json")
 })
 .then(schedule => {
   schedule.map(track => {
-    const trackDay = document.querySelector(`.track[data-day="${track.day}"]`)
+    const trackDay = document.querySelector('.track[data-day="${track.day}"]')
 
     const table = trackDay.querySelector('tbody')
     track.talks.forEach(talk => {

--- a/js/partials.js
+++ b/js/partials.js
@@ -1,3 +1,45 @@
+const RubySummit = {
+  renderSchedule: function() {
+    fetch("data/schedule.json")
+    .then(response => {
+      return response.json()
+    })
+    .then(schedule => {
+      schedule.map(track => {
+        const trackDay = document.querySelector(`.track[data-day="${track.day}"]`)
+
+        const table = trackDay.querySelector('tbody')
+        track.talks.forEach(talk => {
+          name = talk.name ? `<br /> ${talk.name}` : ''
+
+          table.innerHTML +=
+            `
+        <tr class="talk-info">
+        <td>
+          <span title="${talk.hour}"><strong>${talk.hour}</strong></span>
+        </td>
+        <td>
+          <span class="title" title="${talk.title}"><strong>${talk.title}</strong></span>
+          <span class="speaker-name" title="${name}">${name}</span>
+        </td>
+      </tr>
+      `
+          if(talk.description) {
+            table.innerHTML +=
+              `
+        <tr class="talk-description">
+          <td colspan="2">
+            <span class="description" title="${talk.description}">${talk.description}</span>
+          </td>
+        </tr>
+        `
+          }
+        })
+      })
+    })
+  }
+}
+
 fetch("partials/header.html")
 .then(response => {
   return response.text();
@@ -28,45 +70,9 @@ fetch("partials/schedule.html")
 })
 .then(data => {
   document.querySelector("#schedule").innerHTML = data;
+
+  RubySummit.renderSchedule();
 });
-
-fetch("data/schedule.json")
-.then(response => {
-  return response.json()
-})
-.then(schedule => {
-  schedule.map(track => {
-    const trackDay = document.querySelector('.track[data-day="${track.day}"]')
-
-    const table = trackDay.querySelector('tbody')
-    track.talks.forEach(talk => {
-      name = talk.name ? `<br /> ${talk.name}` : ''
-
-      table.innerHTML +=
-        `
-          <tr class="talk-info">
-          <td>
-            <span title="${talk.hour}"><strong>${talk.hour}</strong></span>
-          </td>
-          <td>
-            <span class="title" title="${talk.title}"><strong>${talk.title}</strong></span>
-            <span class="speaker-name" title="${name}">${name}</span>
-          </td>
-        </tr>
-        `
-      if(talk.description) {
-        table.innerHTML +=
-          `
-          <tr class="talk-description">
-            <td colspan="2">
-              <span class="description" title="${talk.description}">${talk.description}</span>
-            </td>
-          </tr>
-          `
-      }
-    })
-  })
-})
 
 fetch("partials/sponsors.html")
 .then(response => {


### PR DESCRIPTION
## Motivation

When accessing website I was getting this exception (Ubuntu Chrome Version 86.0.4240.198):

```js
Uncaught (in promise) TypeError: Cannot read property 'querySelector' of null
    at partials.js:41
    at Array.map (<anonymous>)
    at partials.js:38
(anonymous) @ partials.js:41
(anonymous) @ partials.js:38
Promise.then (async)
(anonymous) @ partials.js:37
```

It seems this caused due `schedule` JSON promise being fetched before `schedule` markup in some cases.

## Proposed solution

Call `renderSchedule` function after `schedule` markup being rendered.

## Screenshot

![image](https://user-images.githubusercontent.com/645452/99811311-c3936a80-2b23-11eb-9251-4847385531de.png)
