### PR TITLE
Adiciona link para as comunidades Ruby

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -9,7 +9,8 @@
   <nav>
     <ul>
       <li><a href="#schedule">Programação</a></li>
-      <li><a href="#speakers">Palestrantes</a></li>
+      <!--<li><a href="#speakers">Palestrantes</a></li>-->
+      <li><a href="http://community.ruby.com.br/" target="_blank">Ruby & Comunidade</a></li>
       <li><a href="#sponsors">Patrocínio</a></li>
       <li><a href="https://www.codamos.club/codigo-de-conduta" target="_blank">Código de Conduta</a></li>
     </ul>


### PR DESCRIPTION
Inicialmente adiciona apenas o link para comunidades

No futuro podemos criar uma sessão nessa landing para adicionar além  das comunidades, uma seção/link para a pessoa se atualizar: https://www.ruby-lang.org/en/